### PR TITLE
fix idt:install

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "dependencies": {
     "fs-extra": "^2.0.0",
-    "generator-ibm-core-node-express": "^0.0.65",
+    "generator-ibm-core-node-express": "^0.0.69",
     "generator-ibm-cloud-enablement": "^0.0.98",
     "generator-ibm-service-enablement": "^0.0.88",
     "handlebars": "^4.0.10",


### PR DESCRIPTION
bump to version 0.0.69 of generator-ibm-core-node-express