### PR TITLE
Added headless mode functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,15 +134,15 @@ yo nodeserver --headless='{"name":"your-app-name","swaggerFileName":"your-swagge
 ```
 
 #### Valid Services
-* alertnotification
-* auth
-* cloudant
-* mongodb
-* objectStorage
-* postgresql
-* push
-* redis
-* conversation
+* 'alert'
+* 'appid'
+* 'cloudant'
+* 'mongo'
+* 'object storage'
+* 'postgre'
+* 'push'
+* 'redis'
+* 'watson conversation'
 
 ### Project Build/Run
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 This generator produces an Express-based Node.js server project with all the ingredients you need for a good start at building a cloud native application. You can choose between either a simple web app or microservice pattern. Combine the microservice pattern with a web app for a
 [backend-for-frontend](http://samnewman.io/patterns/architectural/bff/) pattern.
 
-Bring your own optional [Swagger document](swagger.io) to direct code generation for top-down development.
+Bring your own optional [Swagger document](https://swagger.io/) to direct code generation for top-down development.
 
 ### Monitoring and Health
 

--- a/README.md
+++ b/README.md
@@ -104,18 +104,45 @@ When you run 'yo nodeserver', it will prompt you for the following:
     Specify Y|N whether or not you want to scaffold IBM Cloud service enablement into your project.  If you specify 'Y', you will be able to select one or more services from a checklist. For each service you select,configuration and access scaffolding code is generated.  IBM Cloud service enablement is optional.
 
 ### Headless mode (without prompting)
+Use headless mode to create an app without having to use the UI. This is useful when you want to use this generator to build a project by only running a script instead of interactively.
 
-To create an app where only the name is given (current directory name) run the command:
+To create an app using the default options run the command:
 
 ```bash
 yo nodeserver --headless
 ```
+Defaults:
+* Name: the current working directory.
+* SwaggerFileName: false.
+* Services: false.
 
-To use the full options as listed above, base your command on the following layout:
+#### Headless usage
+To specify the name of the project use:
+```bash
+yo nodeserver --headless='{"name":"your-app-name"}'
+```
 
+To specify which services to add use:
+```bash
+yo nodeserver --headless='{"services":["service1", "service2"]}'
+```
+For valid services see below.
+
+Full usage:
 ```bash
 yo nodeserver --headless='{"name":"your-app-name","swaggerFileName":"your-swagger-file-name","services":["service1", "service2"]}'
 ```
+
+#### Valid Services
+* alertnotification
+* auth
+* cloudant
+* mongodb
+* objectStorage
+* postgresql
+* push
+* redis
+* conversation
 
 ### Project Build/Run
 

--- a/README.md
+++ b/README.md
@@ -29,23 +29,23 @@
 
 ## Overview
 
-This generator produces an Express-based Node.js server project with all the ingredients you need for a good start at building a cloud native application. You can choose between either a simple web app or microservice pattern. Combine the microservice pattern with a web app for a 
+This generator produces an Express-based Node.js server project with all the ingredients you need for a good start at building a cloud native application. You can choose between either a simple web app or microservice pattern. Combine the microservice pattern with a web app for a
 [backend-for-frontend](http://samnewman.io/patterns/architectural/bff/) pattern.
 
 Bring your own optional [Swagger document](swagger.io) to direct code generation for top-down development.
 
-### Monitoring and Health 
+### Monitoring and Health
 
-The generated projects are pre-wired for monitoring and health checks. The app includes 
+The generated projects are pre-wired for monitoring and health checks. The app includes
 
-1. [app metrics dashboard](https://www.npmjs.com/package/appmetrics-dash) 
+1. [app metrics dashboard](https://www.npmjs.com/package/appmetrics-dash)
 
 1. [Prometheus endpoint](https://www.npmjs.com/package/appmetrics-prometheus)
 
 1. [Kubernetes http liveness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/)
 
 ### Deployment Enablement  
- 
+
 The generated projects include deployment configuration for the following environments:
 
 1. Docker
@@ -53,18 +53,18 @@ The generated projects include deployment configuration for the following enviro
     The projects include Docker files to build images for both release and development
 
 1. Kubernetes
-    
-    The projects include a Helm chart for deployment to Kubernetes. 
 
-1. Cloud Foundry 
-    
+    The projects include a Helm chart for deployment to Kubernetes.
+
+1. Cloud Foundry
+
     The projects include a manifest for deployment to Cloud Foundry.
 
-1. Dev-ops Pipeline 
-    
-    The projects include a toolchain and pipeline definition for CI/CD deployment to the IBM Cloud. 
+1. Dev-ops Pipeline
 
-## Special Tools 
+    The projects include a toolchain and pipeline definition for CI/CD deployment to the IBM Cloud.
+
+## Special Tools
 
 The projects include NPM scripts to install and run [IBM Cloud Developer Tools](https://github.com/IBM-Bluemix/ibm-cloud-developer-tools).
 
@@ -84,28 +84,42 @@ npm install -g generator-nodeserver
 ## Usage
 
 ```bash
-yo nodeserver 
+yo nodeserver
 ```
 
 ### Prompting
 
 When you run 'yo nodeserver', it will prompt you for the following:
 
-1. project name 
+1. project name
 
     Specify the project name. It defaults to the current directory name.  This is a required value.
 
-1. Swagger doc file name 
+1. Swagger doc file name
 
     Specify the relative or absolute file name of a Swagger document to direct the project's code generation. A route stub will be scaffolded and registered for each route defined in the swagger document. This is an optional value.
 
-1. IBM Cloud Service Enablement. 
+1. IBM Cloud Service Enablement.
 
     Specify Y|N whether or not you want to scaffold IBM Cloud service enablement into your project.  If you specify 'Y', you will be able to select one or more services from a checklist. For each service you select,configuration and access scaffolding code is generated.  IBM Cloud service enablement is optional.
 
+### Headless mode (without prompting)
+
+To create an app where only the name is given (current directory name) run the command:
+
+```bash
+yo nodeserver --headless
+```
+
+To use the full options as listed above, base your command on the following layout:
+
+```bash
+yo nodeserver --headless='{"name":"your-app-name","swaggerFileName":"your-swagger-file-name","services":["service1", "service2"]}'
+```
+
 ### Project Build/Run
 
-Build your generated project one of two ways: 
+Build your generated project one of two ways:
 
 1. normal npm install, npm start  
 1. containerized, using [IBM Cloud Developer Tools](https://github.com/IBM-Bluemix/ibm-cloud-developer-tools)
@@ -118,62 +132,62 @@ Build your generated project one of two ways:
 
         Installs IBM Cloud Developer Tools.
 
-    1. npm run idt:build 
+    1. npm run idt:build
 
-        Builds Docker image for dev mode and does npm install, including dev dependencies. 
+        Builds Docker image for dev mode and does npm install, including dev dependencies.
 
     1. npm run  idt:test
 
-        Runs project unit tests in dev mode Docker container. 
+        Runs project unit tests in dev mode Docker container.
 
     1. npm run idt:debug
 
-        Runs the project in debug mode in the dev mode Docker container. The app will start and listen on port 5858 by default for a debug client to attach and take control. 
-        
+        Runs the project in debug mode in the dev mode Docker container. The app will start and listen on port 5858 by default for a debug client to attach and take control.
+
     1. npm run idt:run
 
         Runs the project in the release mode Docker container.  The release mode Docker container is built without dev dependencies - i.e. with NODE_ENV set to production.
 
-### Project Deployment 
+### Project Deployment
 
-### Docker 
+### Docker
 
-Build a Docker image and run project in a Docker container using Docker commands in the project root directory: 
+Build a Docker image and run project in a Docker container using Docker commands in the project root directory:
 
 1. docker build -t my-image
-1. docker run -p 3000:3000 --name my-container my-image 
+1. docker run -p 3000:3000 --name my-container my-image
 
 Stop and optionally remove the container and image with the following commands:
 
 1. docker stop my-container
 1. docker rm my-container
-1. docker rmi my-image 
+1. docker rmi my-image
 
-#### Kubernetes Deployment 
+#### Kubernetes Deployment
 
 Deploy to Kubernetes using Helm or the IBM Cloud Developer Tools.
 
 1. Helm
 
-    1. Push your image to a Docker image accessible to your Kubernetes environment, such as [Docker Hub](dockerhub.com) or your company's private image registry. 
+    1. Push your image to a Docker image accessible to your Kubernetes environment, such as [Docker Hub](dockerhub.com) or your company's private image registry.
 
     1. Install your project by installing the included Helm chart, using Helm in the project root directory:
 
-        helm install chart/`<project name>` --name=`<release name>` --set repository=`<image name>` --set tag=`<tag value>` --set pullPolicy=`<pull policy>` 
+        helm install chart/`<project name>` --name=`<release name>` --set repository=`<image name>` --set tag=`<tag value>` --set pullPolicy=`<pull policy>`
 
-        Where: 
+        Where:
 
-        - `<project name>` 
+        - `<project name>`
 
-            The name you gave to your project when you generated it. 
+            The name you gave to your project when you generated it.
 
         - `<release name>`
 
-            An arbitrary name you give to this install instance. 
+            An arbitrary name you give to this install instance.
 
         - `<image name>`
 
-            The registry/image name of your release Docker image - e.g. 
+            The registry/image name of your release Docker image - e.g.
             'registry.ng.bluemix.net/myspace/myimage'
 
         - `<tag value>`
@@ -182,28 +196,28 @@ Deploy to Kubernetes using Helm or the IBM Cloud Developer Tools.
 
         - `<pull policy>`
 
-            'Always' or 'IfNotPresent'.  See [Kubernetes image documentation](https://kubernetes.io/docs/concepts/containers/images/) for further explanation. 
+            'Always' or 'IfNotPresent'.  See [Kubernetes image documentation](https://kubernetes.io/docs/concepts/containers/images/) for further explanation.
 
-    Notes: 
-        
-    
-    1. The helm command installs to the Kubernetes environment pointed to by the KUBECONFIG environment variable. 
-        
+    Notes:
+
+
+    1. The helm command installs to the Kubernetes environment pointed to by the KUBECONFIG environment variable.
+
     1. The Helm command is installed when you install the IBM Cloud Developer Tools, which you can install for your project by running 'npm run idt:install'
 
 1. IBM Cloud Developer Tools
 
-    npm idt:deploy --target container 
+    npm idt:deploy --target container
 
     Notes:
 
-    1. The idt tool will prompt for registry/image name, then push your image and install your Helm chart to the Kubernetes environment pointed to by your KUBECONFIG environment variable. 
-    
+    1. The idt tool will prompt for registry/image name, then push your image and install your Helm chart to the Kubernetes environment pointed to by your KUBECONFIG environment variable.
+
     1. For IBM Cloud, set KUBECONFIG using the 'bx cs cluster-config `<cluster name>` command.  Note this command is installed as part of IBM Cloud Developer Tools, which you can install for your project by running 'npm run idt:install'
 
-#### Clound Foundry Deployment 
- 
-1. cf push 
+#### Clound Foundry Deployment
+
+1. cf push
 
    Note: if you installed IBM Cloud Developer Tools using the 'npm run idt:install' command, you can run the 'bx cf push' command. Otherwise, install the cf command from [Pivotal](https://docs.run.pivotal.io/cf-cli/install-go-cli.html).
 
@@ -226,7 +240,7 @@ npm link
 In a separate directory invoke the generator via
 
 ```bash
-yo nodeserver 
+yo nodeserver
 ```
 
 ## Publishing Changes
@@ -235,6 +249,6 @@ In order to publish changes, you will need to fork the repository or ask to join
 
 Once you are finished with your changes, run `npm test` to make sure all tests pass.
 
-Do a pull request against `development`, make sure the build passes. A team member will review and merge your pull request. 
+Do a pull request against `development`, make sure the build passes. A team member will review and merge your pull request.
 Once merged to development, the version will be auto-incremented.
 Do a pull request against master, once that PR is reviewed and merged, a new version will be published to npm.

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -31,19 +31,22 @@ module.exports = class extends Generator {
     logger.level= "info";
     logger.info("Package info ::", Bundle.name, Bundle.version);
 
-    if ( typeof this.options.bluemix == "undefined" ) { 
+    if ( typeof this.options.bluemix == "undefined" ) {
       // generate only for Node.js apps
       this.opts = {bluemix: {backendPlatform: 'NODE'}, spec: {applicationType: 'WEB'}};
     }
-    else { 
+    else {
       this._sanitizeOption(this.options, OPTION_BLUEMIX);
       this._sanitizeOption(this.options, OPTION_STARTER);
-      this.opts = opts;      
+      this.opts = opts;
     }
+
+    var headlessDesc = 'Run in headless mode (no prompts). Format --headless=\'{"name": "myproject"}\'"'
+    this.option('headless', {desc: headlessDesc, type: String});
 
     /* Do this so there are no overwrite messages when
        subgenerators run. The overwrites are expected
-       by design. 
+       by design.
     */
     this.conflicter.force = true;
   }
@@ -52,93 +55,106 @@ module.exports = class extends Generator {
   }
 
   prompting() {
-    
-    let swaggerFileValidator= function(str) {  
+    let swaggerFileValidator= function(str) {
       if ( str == "None" ) {
         return true;
       }
-      else {  
-        if ( fs.existsSync(str.trim()) ) { 
-          return true; 
-        } 
-        else { 
+      else {
+        if ( fs.existsSync(str.trim()) ) {
+          return true;
+        }
+        else {
           console.log("\n"+str+" not found.");
           return false;
-        } 
-      }    
+        }
+      }
     }
 
     let choseCloudServices= function(answers) {
       return answers.addCloudServices;
     }
+    // If headless mode don't prompt
+    if (this.options.headless) {
+      var json = JSON.parse(this.options.headless);
+      var values = {
+        name: json.name || path.basename(process.cwd()),
+        swaggerFileName: json.swaggerFileName || 'None',
+        addCloudServices: (json.services ? true : false)
+      }
+      // Only add service field to json object if addCloudServices is true
+      if (values.addCloudServices) {
+        values.services = json.services;
+      }
 
-    let prompts = [];
-    prompts.push({
-      type: 'input',
-      name: 'name',
-      message: 'Project name',
-      default: path.basename(process.cwd())
-    });
-    prompts.push({
-      type: 'input',
-      name: 'swaggerFileName',
-      message: 'OpenAPI Document',
-      default: "None",
-      validate: swaggerFileValidator,
-    });
-    prompts.push({
-      type: 'confirm',
-      name: 'addCloudServices',
-      message: 'Add IBM Cloud Service Enablement?',
-      default: false
-    });
-    prompts.push({
-      type: 'checkbox',
-      name: 'services',
-      message: 'Choose IBM Cloud Services',
-      when: choseCloudServices, 
-      choices: services.SERVICE_CHOICES
-    });
-    return this.prompt(prompts).then(this._processAnswers.bind(this));
+      this._processAnswers(values);
+    } else {
+      let prompts = [];
+      prompts.push({
+        type: 'input',
+        name: 'name',
+        message: 'Project name',
+        default: path.basename(process.cwd())
+      });
+      prompts.push({
+        type: 'input',
+        name: 'swaggerFileName',
+        message: 'OpenAPI Document',
+        default: "None",
+        validate: swaggerFileValidator,
+      });
+      prompts.push({
+        type: 'confirm',
+        name: 'addCloudServices',
+        message: 'Add IBM Cloud Service Enablement?',
+        default: false
+      });
+      prompts.push({
+        type: 'checkbox',
+        name: 'services',
+        message: 'Choose IBM Cloud Services',
+        when: choseCloudServices,
+        choices: services.SERVICE_CHOICES
+      });
+
+      return this.prompt(prompts).then(this._processAnswers.bind(this));
+    }
   }
-  
+
   configuring() {}
 
   _processAnswers(answers) {
-
     this.opts.bluemix.backendPlatform = 'NODE';
     this.opts.bluemix.name = answers.name || this.opts.bluemix.name;
     answers.swaggerFileName = answers.swaggerFileName.trim();
-    
-    if ( answers.swaggerFileName.length > 0 && answers.swaggerFileName !== "None" ) {  
-      let swagger = fs.readFileSync(answers.swaggerFileName,"utf8"); 
-      this.opts.bluemix.openApiServers= [{"spec": swagger }]; 
+
+    if ( answers.swaggerFileName.length > 0 && answers.swaggerFileName !== "None" ) {
+      let swagger = fs.readFileSync(answers.swaggerFileName,"utf8");
+      this.opts.bluemix.openApiServers= [{"spec": swagger }];
     }
 
     this._processServices(answers);
-    this._composeSubGenerators(); 
+    this._composeSubGenerators();
   }
 
   // store specified option in bluemix object to drive generator-ibm-service-enablement
   _storeServiceName(service) {
     let service_name= services.SERVICES[services.SERVICE_LABELS.indexOf(service)];
     let service_data= require("./services/"+service_name);
-    this.opts.bluemix[service_name]= service_data[service_name]; 
+    this.opts.bluemix[service_name]= service_data[service_name];
   }
 
-  // process each service selected by user 
-  _processServices(answers) { 
-    
-    if ( answers.services ) { 
-      this.hasServices= true; 
+  // process each service selected by user
+  _processServices(answers) {
+    if ( answers.services ) {
+      this.hasServices= true;
       answers.services.forEach(this._storeServiceName.bind(this));
-    } 
-    else { 
+    }
+    else {
       this.hasServices= false;
     }
   }
 
-  _composeSubGenerators() { 
+  _composeSubGenerators() {
 
     this.opts.bluemix.quiet= true; // suppress version messages
 
@@ -147,15 +163,15 @@ module.exports = class extends Generator {
       this.composeWith('ibm-core-node-express', this.opts);
       this.composeWith('ibm-cloud-enablement', this.opts);
 
-      if ( this.hasServices ) { 
+      if ( this.hasServices ) {
         this.composeWith('ibm-service-enablement', {
-          bluemix: JSON.stringify(this.opts.bluemix), 
+          bluemix: JSON.stringify(this.opts.bluemix),
           spec: JSON.stringify(this.opts.spec),
           starter: "{}",
           quiet: true});
-      } 
+      }
     }
-    else { 
+    else {
       const modDirName = __dirname + '/../../node_modules';
       this.composeWith(
         path.join(
@@ -164,7 +180,7 @@ module.exports = class extends Generator {
           'app'
         ),
         this.opts
-      ); 
+      );
       this.composeWith(
         path.join(
           modDirName,
@@ -173,17 +189,17 @@ module.exports = class extends Generator {
           'app'
         ),
         this.opts
-      );  
+      );
 
       if ( this.hasServices ) {
         this.composeWith(
-          path.join(modDirName,'generator-ibm-service-enablement','generators','app'), 
+          path.join(modDirName,'generator-ibm-service-enablement','generators','app'),
           {
-            bluemix: JSON.stringify(this.opts.bluemix), 
+            bluemix: JSON.stringify(this.opts.bluemix),
             spec: JSON.stringify(this.opts.spec),
             starter: "{}",
-            quiet: true 
-          }); 
+            quiet: true
+          });
       }
     }
   }
@@ -191,7 +207,7 @@ module.exports = class extends Generator {
   _sanitizeOption(options, name) {
 
     try {
-      this.options[name] = typeof (this.options[name]) === 'string' ? 
+      this.options[name] = typeof (this.options[name]) === 'string' ?
         JSON.parse(this.options[name]) : this.options[name];
     } catch (e) {
       throw Error(`${name} parameter is expected to be a valid stringified JSON object`);

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -41,7 +41,7 @@ module.exports = class extends Generator {
       this.opts = opts;
     }
 
-    var headlessDesc = 'Run in headless mode (no prompts). Format --headless=\'{"name": "myproject"}\'"'
+    const headlessDesc = 'Run in headless mode (no prompts). Format --headless=\'{"name": "myproject"}\'"';
     this.option('headless', {desc: headlessDesc, type: String});
 
     /* Do this so there are no overwrite messages when
@@ -75,8 +75,8 @@ module.exports = class extends Generator {
     }
     // If headless mode don't prompt
     if (this.options.headless) {
-      var json = JSON.parse(this.options.headless);
-      var values = {
+      let json = JSON.parse(this.options.headless);
+      let values = {
         name: json.name || path.basename(process.cwd()),
         swaggerFileName: json.swaggerFileName || 'None',
         addCloudServices: (json.services ? true : false)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1303,9 +1303,9 @@
       }
     },
     "generator-ibm-cloud-enablement": {
-      "version": "0.0.77",
-      "resolved": "https://registry.npmjs.org/generator-ibm-cloud-enablement/-/generator-ibm-cloud-enablement-0.0.77.tgz",
-      "integrity": "sha512-WbHdbwuClFdkUifDD9N9WYCbxG6joNxZGsTq1BmRIoX4RMqaLhVykDcyKejsrzIoFfG+kf2IMlD4F61bzFH+tw==",
+      "version": "0.0.98",
+      "resolved": "https://registry.npmjs.org/generator-ibm-cloud-enablement/-/generator-ibm-cloud-enablement-0.0.98.tgz",
+      "integrity": "sha512-ZaB2bBqjocW6jM3iIY45Ae54d2A90CF4a7kzglV/7PkJYFxcWoTpGw9PQWoBE51Wj6nJ/UzWsEdg/ALCi7vK1Q==",
       "requires": {
         "fs-extra": "2.1.2",
         "handlebars": "4.0.10",
@@ -1315,15 +1315,95 @@
       }
     },
     "generator-ibm-core-node-express": {
-      "version": "0.0.55",
-      "resolved": "https://registry.npmjs.org/generator-ibm-core-node-express/-/generator-ibm-core-node-express-0.0.55.tgz",
-      "integrity": "sha512-GsKt75v0y1xnvwMY60+34OsBIu9H9TNaypJ6KVBhYZGVxw2lfAWAMtTR7m/xc4iXbwNe4aGOOYakRZ/DADVbzw==",
+      "version": "0.0.69",
+      "resolved": "https://registry.npmjs.org/generator-ibm-core-node-express/-/generator-ibm-core-node-express-0.0.69.tgz",
+      "integrity": "sha512-FSfXF7MtdhgMDOObXNPGcO5njpC+NCqepwbYlrVypHcpdm77RYU8YKiv5dSe23J3OoZiLyqC20QvkXXyE6lq/A==",
       "requires": {
         "chalk": "1.1.3",
-        "ibm-openapi-support": "0.0.4",
+        "ibm-openapi-support": "0.0.8",
         "log4js": "1.1.1",
         "yeoman-generator": "1.1.1",
         "yosay": "1.2.1"
+      },
+      "dependencies": {
+        "date-format": {
+          "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/date-format/-/date-format-0.0.0.tgz",
+          "integrity": "sha1-CSBoY6sHDrRZrOpVQsvYVrEZZrM="
+        },
+        "ibm-openapi-support": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/ibm-openapi-support/-/ibm-openapi-support-0.0.8.tgz",
+          "integrity": "sha512-KEMYObSIu4pkakOvE278Kx1gZ6r65q+XzbFxe2Gw2la6gW1ZeYLuZ189/Ijc9rnXwq8a9Y/r0lNF0BsWHOL9xQ==",
+          "requires": {
+            "bluebird": "3.5.0",
+            "debug": "2.6.8",
+            "js-yaml": "3.10.0",
+            "request": "2.81.0",
+            "swagger-parser": "3.4.2",
+            "swaggerize-routes": "1.0.11"
+          }
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "log4js": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/log4js/-/log4js-1.1.1.tgz",
+          "integrity": "sha1-wh0px2BAieTyVYM+f5SzRh3h/0M=",
+          "requires": {
+            "debug": "2.6.8",
+            "semver": "5.4.1",
+            "streamroller": "0.4.1"
+          }
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "streamroller": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-0.4.1.tgz",
+          "integrity": "sha1-1DW9WXQ3Or2b2QaDWVEwhRBswF8=",
+          "requires": {
+            "date-format": "0.0.0",
+            "debug": "0.7.4",
+            "mkdirp": "0.5.1",
+            "readable-stream": "1.1.14"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "0.7.4",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+              "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk="
+            }
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
+    "generator-ibm-service-enablement": {
+      "version": "0.0.88",
+      "resolved": "https://registry.npmjs.org/generator-ibm-service-enablement/-/generator-ibm-service-enablement-0.0.88.tgz",
+      "integrity": "sha512-a/Y9OBxB++rCHyHtLB+UZ/PUyRYgw4jr1pw9DuHOHFsc+GzJFJS4XgggBl0NXzlAKT0LaMCSCPmWlSmpPI/Mnw==",
+      "requires": {
+        "handlebars": "4.0.10",
+        "lodash": "4.17.4",
+        "log4js": "1.1.1",
+        "yeoman-generator": "1.1.1"
       },
       "dependencies": {
         "date-format": {
@@ -1648,19 +1728,6 @@
         "agent-base": "2.1.1",
         "debug": "2.6.8",
         "extend": "3.0.1"
-      }
-    },
-    "ibm-openapi-support": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/ibm-openapi-support/-/ibm-openapi-support-0.0.4.tgz",
-      "integrity": "sha512-0fXFHjt/LGThvku+ztbrWc8zORklOYgUX8sGm5FIt+XnE5b0LFk5aqWiYR7hWzi5jac6XQ0ED9JsncVSOj5IDw==",
-      "requires": {
-        "bluebird": "3.5.0",
-        "debug": "2.6.8",
-        "js-yaml": "3.10.0",
-        "request": "2.81.0",
-        "swagger-parser": "3.4.2",
-        "swaggerize-routes": "1.0.11"
       }
     },
     "iconv-lite": {

--- a/test/headlessMode.js
+++ b/test/headlessMode.js
@@ -79,19 +79,9 @@ describe('Headless mode: app integration test with custom spec', function () {
   });
 
   describe(common.file.README_md, function () {
-    it('contains default project name', function () {
-      // TODO assert.fileContent(common.file.README_md, PROJECT_NAME);
-    });
-
     it('contains Bluemix badge', function () {
       assert.fileContent(common.file.README_md,
         '[![](https://img.shields.io/badge/bluemix-powered-blue.svg)](https://bluemix.net)');
-    });
-  });
-
-  describe(common.file.server_js, () => {
-    it('contains default app name', () => {
-      // TODO assert.fileContent(common.file.server_js, 'logger.info(`ProjectName listening on http://localhost:${port}`);')
     });
   });
 
@@ -102,7 +92,7 @@ describe('Headless mode: app integration test with custom spec', function () {
   });
 });
 
-describe('Headless mode: app integration test using purely headless mode (with Swagger file)', function () {
+describe('Headless mode: app integration test using headless mode (with Swagger file)', function () {
   // Express build is slow so we need to set a longer timeout for the test
   this.timeout(150000);
 
@@ -161,19 +151,12 @@ describe('Headless mode: app integration test using purely headless mode (with S
 
   describe(common.fileSwagger.README_md, function () {
     it('contains custom project name', function () {
-      // TODO assert.fileContent(common.file.README_md, PROJECT_NAME);
       assert.fileContent(common.file.README_md, "TEST_APP");
     });
 
     it('contains Bluemix badge', function () {
       assert.fileContent(common.fileSwagger.README_md,
         '[![](https://img.shields.io/badge/bluemix-powered-blue.svg)](https://bluemix.net)');
-    });
-  });
-
-  describe(common.fileSwagger.server_js, () => {
-    it('contains custom app name', () => {
-      // TODO assert.fileContent(common.file.server_js, 'logger.info(`ProjectName listening on http://localhost:${port}`);')
     });
   });
 

--- a/test/headlessMode.js
+++ b/test/headlessMode.js
@@ -102,7 +102,88 @@ describe('Headless mode: app integration test with custom spec', function () {
   });
 });
 
+describe('Headless mode: app integration test using purely headless mode (with Swagger file)', function () {
+  // Express build is slow so we need to set a longer timeout for the test
+  this.timeout(150000);
 
+  before(function () {
+    // Mock the options, set up an output folder and run the generator
+    return helpers.run(path.join( __dirname, '../generators/app'))
+      .withOptions({
+        headless: JSON.stringify({name:'TEST_APP', swaggerFileName: __dirname+"/resources/person_dino.json"})
+      })
+      .toPromise(); // Get a Promise back when the generator finishes
+  });
+
+  describe('basic file structure test', function () {
+    // Files which we assert are created each time the app generator is run.
+    // Takes an array of files, converted from obj by Object.values().
+    const expected = Object.keys(common.fileSwagger).map((key) => common.fileSwagger[key]);
+
+    it('generates the expected application files', function () {
+      assert.file(expected);
+    });
+  });
+
+  describe(common.fileSwagger.local, function () {
+    it('contains the custom port', function () {
+      assert.jsonFileContent(common.fileSwagger.local, {port: common.defaultPort});
+    });
+  });
+
+  describe(common.fileSwagger.package_json, function () {
+    it('check package.json', function () {
+      assert.jsonFileContent(common.fileSwagger.package_json, {
+        "version": "1.0.0",
+        "description": "A generated Bluemix application",
+        "private": true,
+        "engines": {
+          "node": "^6.9.0"
+        },
+        "scripts": {
+          "start": "node server/server.js",
+          "test": "nyc mocha"
+        },
+        "dependencies": {
+          "appmetrics-dash": "^3.3.2",
+          "body-parser": "^1.17.2",
+          "express": "^4.15.3",
+          "log4js": "^1.1.1"
+        },
+        "devDependencies": {
+          "chai": "^4.0.0",
+          "mocha": "^3.4.2",
+          "nyc": "^10.3.2",
+          "proxyquire": "^1.8.0"
+        }});
+    });
+  });
+
+  describe(common.fileSwagger.README_md, function () {
+    it('contains custom project name', function () {
+      // TODO assert.fileContent(common.file.README_md, PROJECT_NAME);
+      assert.fileContent(common.file.README_md, "TEST_APP");
+    });
+
+    it('contains Bluemix badge', function () {
+      assert.fileContent(common.fileSwagger.README_md,
+        '[![](https://img.shields.io/badge/bluemix-powered-blue.svg)](https://bluemix.net)');
+    });
+  });
+
+  describe(common.fileSwagger.server_js, () => {
+    it('contains custom app name', () => {
+      // TODO assert.fileContent(common.file.server_js, 'logger.info(`ProjectName listening on http://localhost:${port}`);')
+    });
+  });
+
+  describe(common.fileSwagger.gitignore, function () {
+    it('contains node_modules', function () {
+      assert.fileContent(common.fileSwagger.gitignore, 'node_modules');
+    });
+  });
+
+});
 
 describe('Headless mode: app integration test chose service watson conversation', function () {
   // Express build is slow so we need to set a longer timeout for the test

--- a/test/headlessMode.js
+++ b/test/headlessMode.js
@@ -1,0 +1,127 @@
+/*
+ Copyright 2017 IBM Corp.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+/**
+ * Tests here do not stub out the subgenerators, so for the app generator
+ * the real build and refresh subgenerators get called.
+ */
+'use strict';
+const common = require('./common.js');
+const path = require('path');
+const assert = require('yeoman-assert');
+const helpers = require('yeoman-test');
+// const PROJECT_NAME = "ProjectName";
+
+describe('Headless mode: app integration test with custom spec', function () {
+  // Express build is slow so we need to set a longer timeout for the test
+  this.timeout(150000);
+
+  before(function () {
+    // Mock the options, set up an output folder and run the generator
+    return helpers.run(path.join( __dirname, '../generators/app'))
+      .withOptions({
+        headless: JSON.stringify({name:'project'})
+      })
+      .toPromise(); // Get a Promise back when the generator finishes
+  });
+
+  describe('basic file structure test', function () {
+    // Files which we assert are created each time the app generator is run.
+    // Takes an array of files, converted from obj by Object.values().
+    const expected = Object.keys(common.file).map((key) => common.file[key]);
+
+    it('generates the expected application files', function () {
+      assert.file(expected);
+    });
+  });
+
+  describe(common.file.local, function () {
+    it('contains the custom port', function () {
+      assert.jsonFileContent(common.file.local, {port: common.defaultPort});
+    });
+  });
+
+  describe(common.file.package_json, function () {
+    it('check package.json', function () {
+      assert.jsonFileContent(common.file.package_json, {
+        "version": "1.0.0",
+        "description": "A generated Bluemix application",
+        "private": true,
+        "engines": {
+          "node": "^6.9.0"
+        },
+        "scripts": {
+          "start": "node server/server.js",
+          "test": "nyc mocha"
+        },
+        "dependencies": {
+          "appmetrics-dash": "^3.3.2",
+          "body-parser": "^1.17.2",
+          "express": "^4.15.3",
+          "log4js": "^1.1.1"
+        },
+        "devDependencies": {
+          "chai": "^4.0.0",
+          "mocha": "^3.4.2",
+          "nyc": "^10.3.2",
+          "proxyquire": "^1.8.0"
+        }});
+    });
+  });
+
+  describe(common.file.README_md, function () {
+    it('contains default project name', function () {
+      // TODO assert.fileContent(common.file.README_md, PROJECT_NAME);
+    });
+
+    it('contains Bluemix badge', function () {
+      assert.fileContent(common.file.README_md,
+        '[![](https://img.shields.io/badge/bluemix-powered-blue.svg)](https://bluemix.net)');
+    });
+  });
+
+  describe(common.file.server_js, () => {
+    it('contains default app name', () => {
+      // TODO assert.fileContent(common.file.server_js, 'logger.info(`ProjectName listening on http://localhost:${port}`);')
+    });
+  });
+
+  describe(common.file.gitignore, function () {
+    it('contains node_modules', function () {
+      assert.fileContent(common.file.gitignore, 'node_modules');
+    });
+  });
+});
+
+
+
+describe('Headless mode: app integration test chose service watson conversation', function () {
+  // Express build is slow so we need to set a longer timeout for the test
+  this.timeout(150000);
+
+  before(function () {
+
+    // Mock the options, set up an output folder and run the generator
+    return helpers.run(path.join( __dirname, '../generators/app'))
+    .withOptions({
+      headless: JSON.stringify({name:'project', services: ["watson conversation"]})
+    })
+      .toPromise(); // Get a Promise back when the generator finishes
+  });
+
+  describe('basic file structure test', function () {
+    it('generates the expected application files', function () {
+      assert.file("server/services/service-watson-conversation.js");
+    });
+  });
+
+});


### PR DESCRIPTION
I've added a headless mode functionality to the generator so that the user is able to use this generator without the prompts. 
The user must supply a `--headless` option to the end of the `yo nodeserver` command. This will create a project using the given defaults much alike using the prompt without entering any values.

To create a custom project the user can do something like:
`yo nodeserver --headless='{"name":"projectname","services":["watson conversation","cloudant"]}'`

I've updated the readme to reflect the added feature as well as listing out which services will be valid to make using headless mode easier.

Testing: I've added three tests.
1. Checks that the project is being created correctly in headless mode.
2. Checks the swagger file name aspect.
3. Checks the services being added.
IMO I don't think we need to add anymore testing as I have shown that the behaviour of headless mode is the same as using prompts.

Would recommend that you viewed the commits with `?w=1` added to the end of the url as my atom has removed a lot of whitespace.