### PR TITLE
fix: Updated so that npm test can use multi mocha reporters

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,6 @@
+{
+  "reporterEnabled":"list, xunit-file",
+  "xunitReporterOptions":{
+    "output":"xunit.xml"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4086,6 +4086,27 @@
         }
       }
     },
+    "mocha-multi-reporters": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/mocha-multi-reporters/-/mocha-multi-reporters-1.1.7.tgz",
+      "integrity": "sha1-zH8/TTL0eFIJQdhSq7ZNmYhYfYI=",
+      "dev": true,
+      "requires": {
+        "debug": "3.1.0",
+        "lodash": "4.17.5"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "modify-values": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "test": "npm run lint && npm run mocha",
     "lint": "eslint .",
-    "mocha": "nyc --reporter=lcov mocha --recursive -R xunit-file",
+    "mocha": "nyc --reporter=lcov mocha --reporter mocha-multi-reporters --reporter-options configFile=config.json",
     "version": "standard-version",
     "coveralls": "nyc report --reporter=text-lcov | coveralls"
   },
@@ -37,9 +37,10 @@
     "eslint": "^3.1.1",
     "eslint-plugin-ejs": "0.0.2",
     "mocha": "^3.2.0",
+    "mocha-multi-reporters": "^1.1.7",
     "nyc": "^10.3.0",
-    "xunit-file": "^1.0.0",
     "standard-version": "^4.3.0",
+    "xunit-file": "^1.0.0",
     "yeoman-assert": "^2.2.2",
     "yeoman-test": "^1.6.0"
   },


### PR DESCRIPTION
Now we can use the standard "list" mocha reporter along with the "xunit-file" mocha reporter. This allows us to see the errors on standard out and adds the output to the xunit file that is used for the devops insights dashboard.